### PR TITLE
Fjern CPU-limit

### DIFF
--- a/nais-dev.yaml
+++ b/nais-dev.yaml
@@ -13,7 +13,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 8080
   liveness:
     path: /isAlive
@@ -27,7 +26,6 @@ spec:
     - https://familie.ekstern.dev.nav.no/familie/alene-med-barn/veiviser
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       memory: 256Mi

--- a/nais-prod.yaml
+++ b/nais-prod.yaml
@@ -20,7 +20,6 @@ spec:
   replicas:
     min: 1
     max: 2
-    cpuThresholdPercentage: 50
   accessPolicy:
     outbound:
       rules:
@@ -33,7 +32,6 @@ spec:
       value: '{{version}}'
   resources:
     limits:
-      cpu: 1000m
       memory: 512Mi
     requests:
       memory: 256Mi


### PR DESCRIPTION
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)