### PR TITLE
Distroless Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM gcr.io/distroless/nodejs:18
+ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY src/assets /app/src/assets
 COPY src/backend /app/src/backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM navikt/node-express:18
-
-ADD ./ /var/server/
-
+FROM gcr.io/distroless/nodejs:18
+WORKDIR /app
+COPY src/assets /app/src/assets
+COPY src/backend /app/src/backend
+COPY node_modules /app/node_modules
+COPY package.json /app/
 EXPOSE 8080
-
-CMD ["node", "src/backend/server.js"]
+CMD ["node", "/app/src/backend/server.js"]


### PR DESCRIPTION
Hvorfor trengs denne endringen ?

Det virker unødvendig å ha egen distro inkludert i docker image, da dette er overflødig og gir potensielt mange sikkerhetshull.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-16237