### PR TITLE
Endret til named import av createClient - da gammel var deprecated. L…

### DIFF
--- a/src/utils/sanity.ts
+++ b/src/utils/sanity.ts
@@ -1,10 +1,11 @@
-import sanityClient from '@sanity/client';
+import { createClient } from '@sanity/client';
 import appEnv from './environment';
 
-export const client = sanityClient({
+export const client = createClient({
   projectId: appEnv.sanityConfig.projectId,
   dataset: appEnv.sanityConfig.dataset,
   useCdn: true,
+  apiVersion: '2024-09-23',
 });
 
 export const hentHeaderQuery = '*[_type == $type][0]{ingress, overskrift}';


### PR DESCRIPTION
…agt til Api version in create client da uten versjon er deprecated.

![image](https://github.com/user-attachments/assets/979274c5-41d1-45cc-948c-912635c49db4)

- Advarslene er borte etter endringene
- Ved å sette apiVersion låses versjonen av APIet som blir brukt i prosjektet - da unngår vi at breaking changes som kan introduseres i fremtiden ikke påvirker prosjektet.


https://www.sanity.io/help/js-client-api-version
