### PR TITLE
Amplitude event i prod

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,7 @@ import {
 import { scrollTilNesteSpørsmal } from './components/spørsmål/SpørsmålUtils';
 import styled, { createGlobalStyle } from 'styled-components';
 import { device, størrelse } from './utils/styles';
-import { logSideBesøk, logStartVeiviser } from './utils/amplitude';
+import { logStartVeiviser } from './utils/amplitude';
 import { IHeader, tomHeaderTekst } from './models/Header';
 import {
   AGray100,
@@ -224,10 +224,6 @@ const App = () => {
 
     scrollTilNesteSpørsmal(nesteSpørsmål);
   };
-
-  useEffect(() => {
-    logSideBesøk();
-  }, []);
 
   const skalViseApp = !feil && spørsmålListe && spørsmålListe.length > 0;
 

--- a/src/utils/amplitude.ts
+++ b/src/utils/amplitude.ts
@@ -1,6 +1,15 @@
 import * as amplitude from '@amplitude/analytics-browser';
 
-amplitude.init('default', undefined, {
+const AMPLITUDE_API_KEY_PROD = '10798841ebeba333b8ece6c046322d76';
+
+const getApiKey = () => {
+  if (!window.location.href.includes('.dev.nav.no')) {
+    return AMPLITUDE_API_KEY_PROD;
+  }
+  return 'default';
+};
+
+amplitude.init(getApiKey(), undefined, {
   serverUrl: 'https://amplitude.nav.no/collect-auto',
   autocapture: true,
 });
@@ -14,13 +23,6 @@ const logEventVeiviser = (eventName: string, eventProperties?: any) => {
     team_id: 'familie',
     applikasjon: 'ef-veiviser',
     ...eventProperties,
-  });
-};
-
-export const logSideBesøk = () => {
-  amplitude.track('EF Veiviser - sidevisning', {
-    sidetittel: document.title,
-    platform: window.location.toString(),
   });
 };
 


### PR DESCRIPTION
Ny custom event (EF Veiviser - skjema fullført) blir ikke logget til prod uten nøkkel.

- Skal sende med event til prod, må derfor ha med nøkkel. 
- Trenger ikke egen event for besøk av side, bruker innebygd fra dekoratør.

Testet at det fortsatt funger i preprod: https://app.eu.amplitude.com/analytics/nav/chart/e-1ndmefs8